### PR TITLE
no-release: Fix error descriptions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ There are several custom errors used in Asset Compute workers:
 
 #### Custom Errors
 | Name  | Description | Type |
-|--------|-------------|
+|--------|-------------|----- |
 | `SourceFormatUnsupportedError` | The source is of an unsupported type. | client error |
 | `RenditionFormatUnsupportedError` | The requested format is unsupported. | client error |
 | `SourceUnsupportedError` | The specific source is unsupported even though the type is supported. | client error |


### PR DESCRIPTION
table was off by one `|---|` so it didn't render correctly