### PR TITLE
Windows support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,3 @@ install:
 
 script:
   - npm test
-
-env:
-  - YARN_GPG=no

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ os:
 
 node_js:
   - "10"
-  - "10.15"
-  - "10.19"
   - "12"
   - "14"
 
@@ -25,4 +23,4 @@ install:
   - npm version
   - npm install
 script:
-  - npm test
+  - npm test && echo "DONE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@
 language: node_js
 os:
   - windows
+  - linux
+  - osx
 
 node_js:
   - "10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ node_js:
   - "14"
 
 install:
-  - echo %YARN_GPG%
   - npm version
   - npm install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,9 @@ node_js:
 install:
   - npm version
   - npm install
+
 script:
-  - npm test && echo "DONE"
+  - npm test
+
+env:
+  - YARN_GPG=no

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ node_js:
   - "14"
 
 install:
+  - echo %YARN_GPG%
   - npm version
   - npm install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@
 
 language: node_js
 os:
-  - linux
-  - osx
   - windows
 
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ install:
 
 script:
   - npm test
+
+env:
+  - YARN_GPG=no

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ language: node_js
 os:
   - linux
   - osx
+  - windows
 
 node_js:
   - "10"

--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
 'use strict';
 
@@ -23,12 +23,12 @@ const actionWrapper = require('./lib/wrap');
 const MetricsTestHelper = require('@adobe/openwhisk-newrelic/lib/testhelper');
 
 module.exports = {
-  OpenwhiskActionName,
-  AssetComputeLogUtils,
-  AssetComputeEvents,
-  AssetComputeMetrics,
-  ...AssetComputeErrors,
-  actionWrapper,
-  /** This requires "nock" to be installed in devDependencies */
-  MetricsTestHelper
+    OpenwhiskActionName,
+    AssetComputeLogUtils,
+    AssetComputeEvents,
+    AssetComputeMetrics,
+    ...AssetComputeErrors,
+    actionWrapper,
+    /** This requires "nock" to be installed in devDependencies */
+    MetricsTestHelper
 };

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1,14 +1,14 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
 'use strict';
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,14 +1,14 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
 'use strict';
 
@@ -94,7 +94,7 @@ class SourceFormatUnsupportedError extends ClientError {
     }
 }
 
- // The specific source is unsupported even though the type is supported.
+// The specific source is unsupported even though the type is supported.
 class SourceUnsupportedError extends ClientError {
     constructor(message) {
         super(message, "SourceUnsupportedError", Reason.SourceUnsupported);
@@ -103,7 +103,7 @@ class SourceUnsupportedError extends ClientError {
     }
 }
 
- // The source data is corrupt. Includes empty files.
+// The source data is corrupt. Includes empty files.
 class SourceCorruptError extends ClientError {
     constructor(message) {
         super(message, "SourceCorruptError", Reason.SourceCorrupt);
@@ -132,4 +132,4 @@ module.exports = {
     SourceCorruptError,
     RenditionTooLarge,
     ArgumentError
-}
+};

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,14 +1,14 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
 'use strict';
 
@@ -35,7 +35,7 @@ class AssetComputeEvents {
 
         if (process.env.ASSET_COMPUTE_UNIT_TEST_OUT) {
             this.fsEventPath = `${process.env.ASSET_COMPUTE_UNIT_TEST_OUT}/events`;
-            console.log(`unit test mode, writing events to filesystem into: ${this.fsEventPath}`)
+            console.log(`unit test mode, writing events to filesystem into: ${this.fsEventPath}`);
             fs.mkdirSync(this.fsEventPath, { recursive: true });
             this.fsEventCounter = 0;
         } else if (params.auth && params.auth.accessToken && orgId && clientId) {

--- a/lib/log-utils.js
+++ b/lib/log-utils.js
@@ -1,14 +1,14 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
 'use strict';
 
@@ -19,17 +19,17 @@ const AssetComputeMetrics = require('./metrics');
 
 // <----------------------- Fields to redact ----------------------->
 const CREDENTIAL_FIELDS_TO_REDACT = [
-                                        "newRelicApiKey", 
-                                        "accessToken", 
-                                        "uploadToken"
-                                    ];
+    "newRelicApiKey",
+    "accessToken",
+    "uploadToken"
+];
 const URL_FIELDS_TO_REDACT = [
-                                "url",
-                                "urls",
-                                "source",
-                                "target",
-                                "x-ms-copy-source"
-                            ];
+    "url",
+    "urls",
+    "source",
+    "target",
+    "x-ms-copy-source"
+];
 
 // <---------------------- Redaction helpers ---------------------->
 // redacts a field by replacing it with "[...REDACTED...]"
@@ -105,7 +105,7 @@ function redact(obj, redactionOptions, silentRemove, callCount=0) {
                 obj = currentRule.redactionFn(obj);
             }
         }
-    }
+    };
 
     if(typeof obj === "string" || Array.isArray(obj)){
         innerFlatFieldRedaction(redactionOptions);
@@ -137,7 +137,7 @@ class AssetComputeLogUtils {
      * Redaction will keep only protocol, hostname and port from
      * the original url.
      *
-     * @param {any} item item with url(s) to redact. 
+     * @param {any} item item with url(s) to redact.
      * Can be a string (single url) or an array of urls or an object containing urls.
      */
     static redactUrl(item) {
@@ -159,9 +159,9 @@ class AssetComputeLogUtils {
     static log(item, message){
         try {
             const rules = [
-                    { redactionList: CREDENTIAL_FIELDS_TO_REDACT, redactionFn: redactField },
-                    { redactionList: URL_FIELDS_TO_REDACT, redactionFn: redactUrls }
-                ];
+                { redactionList: CREDENTIAL_FIELDS_TO_REDACT, redactionFn: redactField },
+                { redactionList: URL_FIELDS_TO_REDACT, redactionFn: redactUrls }
+            ];
             const clonedObj = redact(item, rules, false);
 
             if(message) {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,14 +1,14 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
 'use strict';
 

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -1,14 +1,14 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
 'use strict';
 
@@ -74,11 +74,11 @@ function checkAction(main) {
             return {
                 ok: true,
                 checkAction: true
-            }
+            };
         }
 
         return main(params);
-    }
+    };
 }
 
 function actionWrapper(main) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -969,6 +969,12 @@
         "yaml": "^1.7.2"
       }
     },
+    "cross-os": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/cross-os/-/cross-os-1.3.0.tgz",
+      "integrity": "sha512-9kViqCcAwlPLTeSDPlyC2FdMQ5UVPtGZUnGV8vYDcBA3olJ/hDR7H6IfrNJft2DlKONleHf8CMhD+7Uv2tBnEw==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
       }
     },
     "@adobe/eslint-config-asset-compute": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-asset-compute/-/eslint-config-asset-compute-1.2.0.tgz",
-      "integrity": "sha512-fL4+hPnysq7+sqbKNlkJ50S/97aM+Ym6eELkaorL519JASS0HYO0Iou4Un1Imz1bDry4NGjz9DoQyXFvtdGVUQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-asset-compute/-/eslint-config-asset-compute-1.3.0.tgz",
+      "integrity": "sha512-Ks5y+EFKr8eF+tgViEni2oU8KVFMwM6TrcYijgYnsdUrMj7tM775OcrStwcGGbUz3hQDwo00GnOXV0iFaSFJlw==",
       "dev": true,
       "requires": {
         "eslint": "^6.8.0",
@@ -234,15 +234,6 @@
       "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
       "dev": true
     },
-    "@babel/runtime": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
-      "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
-      "dev": true,
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@babel/template": {
       "version": "7.8.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
@@ -291,13 +282,14 @@
       }
     },
     "@istanbuljs/load-nyc-config": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
-      "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
       },
@@ -317,9 +309,9 @@
       "dev": true
     },
     "@sinonjs/commons": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
-      "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
+      "integrity": "sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -362,26 +354,35 @@
       "dev": true
     },
     "@stryker-mutator/api": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-3.1.0.tgz",
-      "integrity": "sha512-HhfcATYxcIWpzOZ2J8MiqUkNyipF4QvJi8aDxI2r0Zc2aLkJZWj/VMrOuCVX/5AJqCpAJXSeVk/A+z2A15fQEg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-3.2.4.tgz",
+      "integrity": "sha512-WzeLrerYih+xi2HyUtSFKRJq23O4P3HZ669w42MS+q0ivxd953Hr+ZXNfuK6so3jXVzygt5hv3FTyEenm+w0Qg==",
       "dev": true,
       "requires": {
         "mutation-testing-report-schema": "~1.3.0",
         "surrial": "~2.0.2",
-        "tslib": "~1.11.1"
+        "tslib": "~2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
       }
     },
     "@stryker-mutator/core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-3.1.0.tgz",
-      "integrity": "sha512-riO2ccmOklvR5qXVrcEtUBqkryNY27lL85ZkFfcnPtOon0y1XtDClLz/DogLr4FH414RqHBL5ZMjrk0Bf/sKug==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-3.2.4.tgz",
+      "integrity": "sha512-bTPFctIx1iH0YPx0dJxfMfJKyxv9+NIONjEPfrZsJjaUoQFv787s9+bnzD/JUYCYoG6Hj7XjMFsFs97xI318yA==",
       "dev": true,
       "requires": {
-        "@stryker-mutator/api": "^3.1.0",
-        "@stryker-mutator/util": "^3.1.0",
-        "chalk": "~3.0.0",
-        "commander": "~4.1.0",
+        "@stryker-mutator/api": "^3.2.4",
+        "@stryker-mutator/util": "^3.2.4",
+        "ajv": "^6.12.0",
+        "chalk": "~4.0.0",
+        "commander": "~5.1.0",
         "file-url": "~3.0.0",
         "get-port": "~5.0.0",
         "glob": "~7.1.2",
@@ -389,7 +390,7 @@
         "istanbul-lib-instrument": "~3.3.0",
         "lodash.flatmap": "^4.5.0",
         "lodash.groupby": "^4.6.0",
-        "log4js": "6.1.2",
+        "log4js": "6.2.1",
         "mkdirp": "~1.0.3",
         "mutation-testing-elements": "~1.3.0",
         "mutation-testing-metrics": "~1.3.0",
@@ -399,11 +400,23 @@
         "source-map": "~0.7.3",
         "surrial": "~2.0.2",
         "tree-kill": "~1.2.0",
-        "tslib": "~1.11.1",
-        "typed-inject": "~2.1.1",
+        "tslib": "~2.0.0",
+        "typed-inject": "~2.2.1",
         "typed-rest-client": "~1.7.1"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -415,9 +428,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -439,10 +452,22 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "fast-deep-equal": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "dev": true
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
         "mkdirp": {
@@ -459,6 +484,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
         }
       }
     },
@@ -469,92 +500,60 @@
       "dev": true
     },
     "@stryker-mutator/javascript-mutator": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/javascript-mutator/-/javascript-mutator-3.1.0.tgz",
-      "integrity": "sha512-0UUp9f8vnbIo/5lWm91OZGkcb2x8XdlE38AZbrJmYNqENh11ZoZywoKpYyn/sIpmp2CDpAKY+CxWCr8yiFTiZA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/javascript-mutator/-/javascript-mutator-3.2.4.tgz",
+      "integrity": "sha512-Jp64+nBz97Nnn1h9aoBCH7OUtppGf2i1sugeTebp2T4b8cLZsOo2zMEKffCLEesC7+1KNEH0JKzenSen6rM4rw==",
       "dev": true,
       "requires": {
-        "@babel/generator": "~7.8.3",
-        "@babel/parser": "~7.8.3",
-        "@babel/traverse": "~7.8.3",
-        "@stryker-mutator/api": "^3.1.0",
-        "tslib": "~1.11.1"
+        "@babel/generator": "~7.9.4",
+        "@babel/parser": "~7.9.4",
+        "@babel/traverse": "~7.9.5",
+        "@stryker-mutator/api": "^3.2.4",
+        "tslib": "~2.0.0"
       },
       "dependencies": {
-        "@babel/generator": {
-          "version": "7.8.8",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
-          "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.8.7",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.8.8",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-          "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA==",
-          "dev": true
-        },
-        "@babel/traverse": {
-          "version": "7.8.6",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
-          "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@babel/generator": "^7.8.6",
-            "@babel/helper-function-name": "^7.8.3",
-            "@babel/helper-split-export-declaration": "^7.8.3",
-            "@babel/parser": "^7.8.6",
-            "@babel/types": "^7.8.6",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.13"
-          }
-        },
-        "globals": {
-          "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
           "dev": true
         }
       }
     },
     "@stryker-mutator/mocha-framework": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/mocha-framework/-/mocha-framework-3.1.0.tgz",
-      "integrity": "sha512-tTgivRwRBoCOkBLIDrVlTvpHxAIFLhdAYn1+3AjOEH+fO90W58OPBmixon3E2Xwro3XsGEQCzeJyA40Qo6v4FA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/mocha-framework/-/mocha-framework-3.2.4.tgz",
+      "integrity": "sha512-BzE+B++Maex3wZ9Wk45ARoZwNLTCxI4/dB9cK0WhJhS4QLvacF8sOuEhKuUDLprIAW3h0nOKpUONiyBdQR2+vQ==",
       "dev": true,
       "requires": {
-        "@stryker-mutator/api": "^3.1.0",
-        "@stryker-mutator/util": "^3.1.0"
+        "@stryker-mutator/api": "^3.2.4",
+        "@stryker-mutator/util": "^3.2.4"
       }
     },
     "@stryker-mutator/mocha-runner": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/mocha-runner/-/mocha-runner-3.1.0.tgz",
-      "integrity": "sha512-Zg4jisPRmZDV2i4TUIJTsh8TmInSuVHZ0AMyY7vWdvxD0EQUBW+CrnDsfmhmiRpUej6jM8kc/XuqOZetO8dZ4A==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/mocha-runner/-/mocha-runner-3.2.4.tgz",
+      "integrity": "sha512-RCO/mmukG8hJ4mYVUxMr/pmfx1RM+49ORc1PaG0IhDM/v0cQuGdrZfG9VEdOEAg1CbA9cMMFRT84V1y0Tot8zA==",
       "dev": true,
       "requires": {
-        "@stryker-mutator/api": "^3.1.0",
+        "@stryker-mutator/api": "^3.2.4",
+        "@stryker-mutator/util": "^3.2.4",
         "multimatch": "~4.0.0",
-        "tslib": "~1.11.1"
+        "tslib": "~2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
+          "dev": true
+        }
       }
     },
     "@stryker-mutator/util": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-3.1.0.tgz",
-      "integrity": "sha512-9u5cekP4VfYOdrBoRIJeYiVXiW/5EQfwPe029GFNn07OiSDsikiQQDI23xzew3DzDFTzQfN1dsPgqjB/r5kolw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-3.2.4.tgz",
+      "integrity": "sha512-s/yB6Ok0NZfGlQD1A/3BPdwCyS2YA5yQzIFNsFE8q/GqmMlZ5SjliEFNgp7u3LUYpqqBStmmz6qzP/PoL1BxqQ==",
       "dev": true
     },
     "@types/color-name": {
@@ -923,9 +922,9 @@
       }
     },
     "commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "dev": true
     },
     "commondir": {
@@ -1616,6 +1615,12 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
     "get-port": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.0.0.tgz",
@@ -2265,21 +2270,21 @@
       }
     },
     "lockfile-lint": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/lockfile-lint/-/lockfile-lint-4.2.2.tgz",
-      "integrity": "sha512-9mr2eiFlIhr9AIlmpQlAeSd7Aov+7viRShnzymaFF4lUO6si7mODueTG5fWH0Jnb49nL0Tjsudw5lD/nu4qVqA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/lockfile-lint/-/lockfile-lint-4.3.6.tgz",
+      "integrity": "sha512-W2N4Ygeispqv8elwO+Amw8WTOukC5zw0taDxpwKkUE6/FCfUl/I05uoNgqLODD6i0oTw6iohwTHHd/b1fhLFFw==",
       "dev": true,
       "requires": {
         "cosmiconfig": "^6.0.0",
         "debug": "^4.1.1",
-        "lockfile-lint-api": "^5.1.2",
+        "lockfile-lint-api": "^5.1.6",
         "yargs": "^15.0.2"
       }
     },
     "lockfile-lint-api": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/lockfile-lint-api/-/lockfile-lint-api-5.1.2.tgz",
-      "integrity": "sha512-ePXCaoGFxXf8ggGPw+rxaopOMQaBm4HrV5iILVvx8qR406R4HEW9MyReEVHaP0IGxp45rzPm/euimkS78icbGg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/lockfile-lint-api/-/lockfile-lint-api-5.1.6.tgz",
+      "integrity": "sha512-liJ1p/NkHbE2Wx5fRw8T1io+x2b2DttVvXpHLm4x7QC8pW3Lc6sHqV4T7cM6rAOs4fF2O9sAt7SEtuN2sX91qA==",
       "dev": true,
       "requires": {
         "@yarnpkg/lockfile": "^1.1.0",
@@ -2362,16 +2367,16 @@
       }
     },
     "log4js": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.1.2.tgz",
-      "integrity": "sha512-knS4Y30pC1e0n7rfx3VxcLOdBCsEo0o6/C7PVTGxdVK+5b1TYOSGQPn9FDcrhkoQBV29qwmA2mtkznPAQKnxQg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.2.1.tgz",
+      "integrity": "sha512-7n+Oqxxz7VcQJhIlqhcYZBTpbcQ7XsR0MUIfJkx/n3VUjkAS4iUr+4UJlhxf28RvP9PMGQXbgTUhLApnu0XXgA==",
       "dev": true,
       "requires": {
         "date-format": "^3.0.0",
         "debug": "^4.1.1",
         "flatted": "^2.0.1",
         "rfdc": "^1.1.4",
-        "streamroller": "^2.2.3"
+        "streamroller": "^2.2.4"
       }
     },
     "make-dir": {
@@ -3072,12 +3077,6 @@
       "requires": {
         "picomatch": "^2.0.4"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-      "dev": true
     },
     "regexpp": {
       "version": "2.0.1",
@@ -3880,9 +3879,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-      "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
     },
     "tunnel": {
@@ -3913,13 +3912,10 @@
       "dev": true
     },
     "typed-inject": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-2.1.1.tgz",
-      "integrity": "sha512-TaQrNsYjGTMmgfEwKtjP9+qyZu//H1RJ0RYNvvQ/rcAnpQGZLxHajb+O6TnyFZGfLaK/9319VYaG4PFXGjImug==",
-      "dev": true,
-      "requires": {
-        "typescript": "^3.6.3"
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-2.2.1.tgz",
+      "integrity": "sha512-+PFtxIKTfrfuqba42XYmTotRCoPC8U7/cIQSu9bHhRlHLDazrbagEDzJ8mjnVVUzgrAlseFx0qKwvf6ua5Yzmg==",
+      "dev": true
     },
     "typed-rest-client": {
       "version": "1.7.3",
@@ -3940,12 +3936,6 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
-      "dev": true
     },
     "underscore": {
       "version": "1.8.3",
@@ -4128,13 +4118,10 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
-      "integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+      "dev": true
     },
     "yargs": {
       "version": "15.3.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "posttest-cross-os": {
       "darwin": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
       "linux": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
-      "win32": "eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
+      "win32": "tasklist && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
     }
   },
   "mocha": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "posttest-cross-os": {
       "darwin": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
       "linux": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
-      "win32": "taskkill /IM \"node.exe\" /F && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
+      "win32": "taskkill /IM \"sh.exe\" /F && taskkill /IM \"node.exe\" /F && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
     }
   },
   "mocha": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
       "darwin": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
       "linux": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
       "win32": "taskkill /IM \"sh.exe\" /F && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
-    },
+    }
   },
   "mocha": {
     "file": "test/logfile.setup.js"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@stryker-mutator/javascript-mutator": "^3.1.0",
     "@stryker-mutator/mocha-framework": "^3.1.0",
     "@stryker-mutator/mocha-runner": "^3.1.0",
+    "cross-os": "^1.3.0",
     "jsonwebtoken": "^8.5.1",
     "lockfile-lint": "^4.2.2",
     "mocha": "^7.1.2",
@@ -41,8 +42,20 @@
     "adobe"
   ],
   "scripts": {
-    "posttest": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
-    "test": "nyc --reporter=html --reporter=text mocha ./test/*"
+    "posttest": "cross-os posttest-cross-os",
+    "test": "cross-os test-cross-os"
+  },
+  "cross-os": {
+    "posttest-cross-os": {
+      "darwin": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
+      "linux": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
+      "win32": "eslint && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
+    },
+    "test-cross-os": {
+      "darwin": "nyc --reporter=html --reporter=text mocha ./test/*",
+      "linux": "nyc --reporter=html --reporter=text mocha ./test/*",
+      "win32": "nyc --reporter=html --reporter=text mocha test/*"
+    }
   },
   "mocha": {
     "file": "test/logfile.setup.js"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "posttest-cross-os": {
       "darwin": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
       "linux": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
-      "win32": "taskkill /IM \"sh.exe\" /F && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
+      "win32": "taskkill /IM \"sh.exe\" /F && taskkill /IM \"node.exe\" /F && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
     }
   },
   "mocha": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "posttest-cross-os": {
       "darwin": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
       "linux": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
-      "win32": "tasklist && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
+      "win32": "tasklist && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true && echo DONE && taskkill /IM \"sh.exe\" /F"
     }
   },
   "mocha": {

--- a/package.json
+++ b/package.json
@@ -42,19 +42,25 @@
     "adobe"
   ],
   "scripts": {
-    "posttest": "cross-os posttest-cross-os",
-    "test": "cross-os test-cross-os"
+    "pretest": "cross-os pretest-cross-os",
+    "test": "cross-os test-cross-os",
+    "posttest": "cross-os posttest-cross-os"
   },
   "cross-os": {
-    "posttest-cross-os": {
-      "darwin": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
-      "linux": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
-      "win32": "eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
-    },
+      "pretest-cross-os": {
+        "darwin": "echo $YARN_GPG",
+        "linux": "echo $YARN_GPG",
+        "win32": "echo %YARN_GPG%"
+      },
     "test-cross-os": {
       "darwin": "nyc --reporter=html --reporter=text mocha ./test/*",
       "linux": "nyc --reporter=html --reporter=text mocha ./test/*",
       "win32": "nyc --reporter=html --reporter=text mocha test/*"
+    },
+    "posttest-cross-os": {
+      "darwin": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
+      "linux": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
+      "win32": "eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
     }
   },
   "mocha": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "posttest-cross-os": {
       "darwin": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
       "linux": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
-      "win32": "taskkill /IM \"sh.exe\" /F && taskkill /IM \"node.exe\" /F && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
+      "win32": "taskkill /IM \"node.exe\" /F && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
     }
   },
   "mocha": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "posttest-cross-os": {
       "darwin": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
       "linux": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
-      "win32": "tasklist && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true && echo DONE && taskkill /IM \"sh.exe\" /F"
+      "win32": "tasklist && taskkill /IM \"sh.exe\" /F && taskkill /IM \"node.exe\" /F && echo DONE && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
     }
   },
   "mocha": {

--- a/package.json
+++ b/package.json
@@ -42,16 +42,10 @@
     "adobe"
   ],
   "scripts": {
-    "pretest": "cross-os pretest-cross-os",
     "test": "cross-os test-cross-os",
     "posttest": "cross-os posttest-cross-os"
   },
   "cross-os": {
-      "pretest-cross-os": {
-        "darwin": "echo $YARN_GPG",
-        "linux": "echo $YARN_GPG",
-        "win32": "echo %YARN_GPG%"
-      },
     "test-cross-os": {
       "darwin": "nyc --reporter=html --reporter=text mocha ./test/*",
       "linux": "nyc --reporter=html --reporter=text mocha ./test/*",
@@ -60,8 +54,8 @@
     "posttest-cross-os": {
       "darwin": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
       "linux": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
-      "win32": "tasklist && taskkill /IM \"sh.exe\" /F && taskkill /IM \"node.exe\" /F && echo DONE && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
-    }
+      "win32": taskkill /IM \"sh.exe\" /F && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
+    },
   },
   "mocha": {
     "file": "test/logfile.setup.js"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "posttest-cross-os": {
       "darwin": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
       "linux": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
-      "win32": taskkill /IM \"sh.exe\" /F && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
+      "win32": "taskkill /IM \"sh.exe\" /F && eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
     },
   },
   "mocha": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "posttest-cross-os": {
       "darwin": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
       "linux": "eslint ./ && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
-      "win32": "eslint && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
+      "win32": "eslint ../ && node_modules\\lockfile-lint\\bin\\lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true"
     },
     "test-cross-os": {
       "darwin": "nyc --reporter=html --reporter=text mocha ./test/*",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "valid-url": "^1.0.9"
   },
   "devDependencies": {
-    "@adobe/eslint-config-asset-compute": "^1.2.0",
+    "@adobe/eslint-config-asset-compute": "^1.3.0",
     "@stryker-mutator/core": "^3.1.0",
     "@stryker-mutator/html-reporter": "^3.1.0",
     "@stryker-mutator/javascript-mutator": "^3.1.0",

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -1,22 +1,22 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
-
-'use strict'
+'use strict';
 
 module.exports = function(config) {
     config.set({
         mutator: "javascript",
         files: [
-            'test/*.js', 'lib/*.js', 'index.js', 
+            'test/*.js', 'lib/*.js', 'index.js',
         ],
         packageManager: "npm",
         reporters: ["html", "clear-text", "progress"],

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -1,14 +1,14 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
 'use strict';
 

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -1,4 +1,15 @@
 /*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -1,4 +1,15 @@
 /*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
@@ -32,7 +43,7 @@ const FAKE_PARAMS = {
         accessToken: jsonwebtoken.sign({client_id: "clientId"}, "key"),
         appName:"appName"
     }
-}
+};
 
 const FAKE_PARAMS_NO_AUTH = {
     newRelicEventsURL: MetricsTestHelper.MOCK_URL,
@@ -142,7 +153,7 @@ describe("AssetComputeEvents", function() {
             ...FAKE_PARAMS,
             metrics: new AssetComputeMetrics(FAKE_PARAMS, { sendImmediately: true })
         },
-            false
+        false
         );
         await events.sendEvent("my_event", {test: "value"});
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,15 @@
 /*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
@@ -26,7 +37,7 @@ describe("index.js", function() {
         assert.strictEqual(typeof commons.AssetComputeMetrics, "function");
         Object.keys(AssetComputeErrors).forEach(key => {
             assert.strictEqual(commons[key], AssetComputeErrors[key]);
-        })
+        });
         assert.strictEqual(typeof commons.actionWrapper, "function");
         assert.strictEqual(typeof commons.MetricsTestHelper, "object");
     });

--- a/test/log-utils.test.js
+++ b/test/log-utils.test.js
@@ -1,4 +1,15 @@
 /*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
@@ -453,7 +464,7 @@ describe("log-utils.js - Custom fields redaction", function() {
         parentObj.testObj = testObj;
 
         const options = [
-            {redactionList: ["oneField", "twoField", "threeField"], redactionFn: function (){ return "[...REDACTED...]"} }
+            {redactionList: ["oneField", "twoField", "threeField"], redactionFn: function (){ return "[...REDACTED...]";} }
         ];
 
         const redact = rewiredRedact.__get__("redact");
@@ -479,9 +490,9 @@ describe("log-utils.js - Custom fields redaction", function() {
         parentObj.testObj = testObj;
 
         const options = [
-                            {redactionList: ["oneField", "twoField"], redactionFn: function (){ return "[...REDACTED2...]"} },
-                            {redactionList: ["threeField"], redactionFn: function (){ return "[...REDACTED3...]"} },
-                        ];
+            {redactionList: ["oneField", "twoField"], redactionFn: function (){ return "[...REDACTED2...]";} },
+            {redactionList: ["threeField"], redactionFn: function (){ return "[...REDACTED3...]";} },
+        ];
 
         const redact = rewiredRedact.__get__("redact");
         const redactedObject = redact(parentObj, options);
@@ -507,7 +518,7 @@ describe("log-utils.js - Custom fields removal", function() {
 
         parentObj.testObj = testObj;
 
-        const options = [ {redactionList: ["threeField", "oneField", "twoField"], redactionFn: function (){ return "[...REDACTED...]"} } ];
+        const options = [ {redactionList: ["threeField", "oneField", "twoField"], redactionFn: function (){ return "[...REDACTED...]";} } ];
 
         const redact = rewiredRedact.__get__("redact");
         const redactedObject = redact(parentObj, options, true);

--- a/test/logfile.setup.js
+++ b/test/logfile.setup.js
@@ -1,4 +1,15 @@
 /*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
@@ -88,7 +99,7 @@ before(function() {
         } else {
             fileWrite(logFile, util.format(...args) + "\n");
         }
-    }
+    };
     console.info = console.log;
     console.debug = console.log;
     console.warn = console.error;

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -1,4 +1,15 @@
 /*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
@@ -399,7 +410,7 @@ describe("AssetComputeMetrics", function() {
             timestamp: /\d+/,
             appName: "appName",
             requestId: "requestId"
-        }
+        };
         const receivedMetrics = MetricsTestHelper.mockNewRelic();
 
         const metrics = new AssetComputeMetrics(FAKE_PARAMS);
@@ -431,7 +442,7 @@ describe("AssetComputeMetrics", function() {
         });
 
         await sleep(100);
-        assert.equal(receivedMetrics.length, 0, "it did send metrics although it should not")
+        assert.equal(receivedMetrics.length, 0, "it did send metrics although it should not");
     });
 
     it("send timeout metrics", async function() {
@@ -538,7 +549,7 @@ describe("AssetComputeMetrics", function() {
         it("sendMetrics fails", async function() {
             const failedMetricsNock = nock(MetricsTestHelper.MOCK_BASE_URL)
                 .post(MetricsTestHelper.MOCK_URL_PATH)
-                .reply(500)
+                .reply(500);
 
             const metrics = new AssetComputeMetrics(FAKE_PARAMS);
             await metrics.sendMetrics(EVENT_TYPE, { test: "value" });
@@ -556,7 +567,7 @@ describe("AssetComputeMetrics", function() {
                 requestId: "requestId",
                 package: "package",
                 timestamp: /\d+/
-            }
+            };
             const receivedMetrics = MetricsTestHelper.mockNewRelic();
 
             const metrics = new AssetComputeMetrics({

--- a/test/wrap.test.js
+++ b/test/wrap.test.js
@@ -178,7 +178,7 @@ describe("wrap", function() {
                 assert.fail("did not pass through error");
             }
 
-            await MetricsTestHelper.metricsDone();
+            await MetricsTestHelper.metricsDone(400);
             MetricsTestHelper.assertArrayContains(receivedMetrics, [{
                 eventType: "error",
                 timestamp: /\d+/,

--- a/test/wrap.test.js
+++ b/test/wrap.test.js
@@ -1,4 +1,15 @@
 /*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
@@ -130,7 +141,7 @@ describe("wrap", function() {
         it('metrics wrapper catches errors', async function() {
             const receivedMetrics = MetricsTestHelper.mockNewRelic();
 
-            process.env.__OW_ACTION_NAME = "my-action"
+            process.env.__OW_ACTION_NAME = "my-action";
 
             function main(params) {
                 assert.equal(typeof params, "object");


### PR DESCRIPTION
Added pathing specific to windows in package.json
Removed 10.15 and 10.19 NodeJs version from Travis config
Updated eslint to the latest OS version and fixed complaints
Added `cross-os` to dev dependencies in order to call OS specific commands and pathing syntax
Upped meticsDone() time for one test that was randomly failing for `metrics wrapper catches errors`
Windows was passing but hanging, I found that killing the sh and node processes that were running in the background after a successful run to fix the issue - setting YARN_GPG=no did not work