### PR TITLE
FEATURE-RELEASE: redact ow headers

### DIFF
--- a/lib/log-utils.js
+++ b/lib/log-utils.js
@@ -21,7 +21,8 @@ const AssetComputeMetrics = require('./metrics');
 const CREDENTIAL_FIELDS_TO_REDACT = [
     "newRelicApiKey",
     "accessToken",
-    "uploadToken"
+    "uploadToken",
+    "__ow_headers"
 ];
 const URL_FIELDS_TO_REDACT = [
     "url",

--- a/test/log-utils.test.js
+++ b/test/log-utils.test.js
@@ -57,6 +57,7 @@ describe("log-utils.js - Credentials redaction", function() {
         testObj.accessToken = "accessToken";
         testObj.uploadToken = "uploadToken";
         testObj.noRedact = "no-redact";
+        testObj.__ow_headers = "owHeaders";
 
         const fieldsToRedact = rewiredRedact.__get__("CREDENTIAL_FIELDS_TO_REDACT");
         const redactField = rewiredRedact.__get__("redactField");
@@ -72,6 +73,31 @@ describe("log-utils.js - Credentials redaction", function() {
         assert.equal(redactedObject.accessToken, "[...REDACTED...]");
         assert.equal(redactedObject.uploadToken, "[...REDACTED...]");
         assert.equal(redactedObject.noRedact, "no-redact");
+        assert.equal(redactedObject.__ow_headers, "[...REDACTED...]");
+    });
+
+    it('redact entire object from a field', function() {
+        const testObj = {};
+        testObj.noRedact = "no-redact";
+        testObj.__ow_headers = {
+            "authorization": "authorization",
+            "connection": "close",
+            "content-type": "application/json",
+            "x-api-key": "apiKey",
+            "x-gw-ims-client-id": "clientId",
+            "x-gw-ims-org-id": "orgId",
+            "x-ims-access-token": "accessToken"
+        };
+        const fieldsToRedact = rewiredRedact.__get__("CREDENTIAL_FIELDS_TO_REDACT");
+        const redactField = rewiredRedact.__get__("redactField");
+        const options = [
+            {redactionList: fieldsToRedact, redactionFn: redactField }
+        ];
+        const redact = rewiredRedact.__get__("redact");
+        const redactedObject = redact(testObj, options, false);
+
+        assert.equal(redactedObject.noRedact, "no-redact");
+        assert.equal(redactedObject.__ow_headers, "[...REDACTED...]");
     });
 
     it("redacts urls from header fields", function () {
@@ -287,6 +313,7 @@ describe("log-utils.js - Credentials removal", function() {
         testObj.newRelicApiKey = "newRelicApiKey";
         testObj.accessToken = "accessToken";
         testObj.uploadToken = "uploadToken";
+        testObj.__ow_headers = "owHeaders";
         testObj.noRedact = "no-redact";
 
         const fieldsToRedact = rewiredRedact.__get__("CREDENTIAL_FIELDS_TO_REDACT");
@@ -302,8 +329,34 @@ describe("log-utils.js - Credentials removal", function() {
         assert.equal(redactedObject.newRelicApiKey, undefined);
         assert.equal(redactedObject.accessToken, undefined);
         assert.equal(redactedObject.uploadToken, undefined);
+        assert.equal(redactedObject.__ow_headers, undefined);
         assert.equal(redactedObject.noRedact, "no-redact");
     });
+
+    it('redact entire object from a field', function() {
+        const testObj = {};
+        testObj.noRedact = "no-redact";
+        testObj.__ow_headers = {
+            "authorization": "authorization",
+            "connection": "close",
+            "content-type": "application/json",
+            "x-api-key": "apiKey",
+            "x-gw-ims-client-id": "clientId",
+            "x-gw-ims-org-id": "orgId",
+            "x-ims-access-token": "accessToken"
+        };
+        const fieldsToRedact = rewiredRedact.__get__("CREDENTIAL_FIELDS_TO_REDACT");
+        const redactField = rewiredRedact.__get__("redactField");
+        const options = [
+            {redactionList: fieldsToRedact, redactionFn: redactField }
+        ];
+        const redact = rewiredRedact.__get__("redact");
+        const redactedObject = redact(testObj, options, true);
+
+        assert.equal(redactedObject.noRedact, "no-redact");
+        assert.equal(redactedObject.__ow_headers, undefined);
+    });
+
 
     it("redacts nested fields (all fields in one level)", function() {
         const parentObj = {};


### PR DESCRIPTION
## Description

Looking at the actions, the ow headers do not get logged directly. They get logged as part of the params in `api-process`: https://git.corp.adobe.com/nui/api-process/blob/master/process.js#L77 and https://git.corp.adobe.com/nui/api-process/blob/master/process.js#L95

changes:
- Added `__ow_headers` to the block-list in log-utils 

Fixes # https://jira.corp.adobe.com/browse/NUI-199

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
