### PR TITLE
BUG-FIX: add parameter to send metrics immediately

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -83,9 +83,10 @@ class AssetComputeMetrics {
      *
      * @param {string} eventType event type for the metric event
      * @param {object} metrics all custom metrics to be included in the New Relic event
+     * @param {Boolean} immediately Set to true to immediately send this event.
      */
-    async sendMetrics(eventType, metrics) {
-        await this.newRelic.send(eventType, metrics);
+    async sendMetrics(eventType, metrics, immediately) {
+        await this.newRelic.send(eventType, metrics, immediately);
     }
 
     async sendErrorMetrics(location, message, metrics) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@adobe/asset-compute-commons",
   "description": "Common utilities needed by all Adobe Asset Compute serverless actions",
   "license": "Apache-2.0",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index.js",
   "author": {
     "name": "Adobe Inc."


### PR DESCRIPTION
## Description

I came across this when I wanted to send a manual timeout metric in the sdk. See comment [here](https://github.com/adobe/asset-compute-sdk/pull/21#discussion_r457843910). I wanted to ensure it gets sent immediately by having access to the [`immediately`](https://github.com/adobe/node-openwhisk-newrelic/blob/af62c5ce3e3c465655e624b73d81d290ed39e03e/lib/newrelic.js#L141) param in newrelic `send` method

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
