### PR TITLE
Travis CI: add sizewatcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,6 @@ jobs:
 
 after_success:
   - npm run report-coverage
+
+after_script:
+  - npx @adobe/sizewatcher


### PR DESCRIPTION
This updates the travis CI jobs to run [@adobe/sizewatcher](https://github.com/adobe/sizewatcher).

This tool warns if pull requests introduce large size increases (e.g. npm modules dependencies, package size etc.).

All sizewatcher PRs:

- [x] https://github.com/adobe/asset-compute-sdk/pull/74
- [x] https://github.com/adobe/node-metrics-sampler/pull/14
- [x] https://github.com/adobe/asset-compute-commons/pull/47
   - double reported comment (see below)
   - seems a rare case as it already has a check for that but it's not 100% atomic, and happens if two builds (e.g. different node versions) run at _exactly_ the same time
   - could also be prevented by running as separate travis ci phase so it only runs once instead of using `after_script`
- [x] https://github.com/adobe/asset-compute-client/pull/37
- [ ] https://github.com/adobe/asset-compute-example-workers/pull/22
    - did not succeed due to `Not inside the root of a git checkout`
    - needs https://github.com/adobe/sizewatcher/issues/41
- [ ] https://github.com/adobe/asset-compute-events-client/pull/14
    - does not run Travis CI since it's a private repo
    - suggest to just merge in case we ever get Travis to run there
- [ ] https://github.com/adobe/asset-compute-devtool/pull/41
    - did not succeed due to `Not inside the root of a git checkout`
    - needs https://github.com/adobe/sizewatcher/issues/41
- [x] https://github.com/adobe/aio-cli-plugin-asset-compute/pull/46
- [ ] https://github.com/adobe/asset-compute-integration-tests/pull/10
    - issue with npm_package as there is no version field in package.json: https://github.com/adobe/sizewatcher/issues/42
    - issue with node_modules as there are no dependencies and cost-of-modules returns non-zero exit code https://github.com/adobe/sizewatcher/issues/43
    - see [travis job](https://travis-ci.com/github/adobe/asset-compute-integration-tests/jobs/412213493)
- [x] https://github.com/adobe/node-fetch-retry/pull/35
- [x] https://github.com/adobe/node-httptransfer/pull/21
- [x] https://github.com/adobe/node-openwhisk-newrelic/pull/23
- [x] https://github.com/adobe/node-cloud-blobstore-wrapper/pull/16
- [x] https://github.com/adobe/node-cgroup-metrics/pull/34

(checked box indicates it was ok and merged)