### PR TITLE
NUI-1577 extend redacted list to include azure auth object

### DIFF
--- a/lib/log-utils.js
+++ b/lib/log-utils.js
@@ -23,7 +23,8 @@ const CREDENTIAL_FIELDS_TO_REDACT = [
     "accessToken",
     "uploadToken",
     "__ow_headers",
-    "Authorization"
+    "Authorization",
+    "azureAuth"
 ];
 const URL_FIELDS_TO_REDACT = [
     "url",

--- a/test/log-utils.test.js
+++ b/test/log-utils.test.js
@@ -728,6 +728,11 @@ describe("log-utils.js - Url redaction", function(){
             "https://adobe80.com:8080/something?query=stuff",
             "https://adobe.80.com:8080/something?query=stuff"
         ];
+        testObj.azureAuth = {
+            aadTenantDomain: 'aadTenantDomain',
+            azureClientId: 'azureClientId',
+            azureClientSecret: 'azureClientSecret'
+        };
 
         AssetComputeLogUtils.log(testObj, "my message");
         AssetComputeLogUtils.log(testObj);
@@ -749,6 +754,7 @@ describe("log-utils.js - Url redaction", function(){
         assert.equal(spyCallArgs.urls[5], "https://adobe1.com:8181");
         assert.equal(spyCallArgs.urls[6], "https://adobe80.com:8080");
         assert.equal(spyCallArgs.urls[7], "https://adobe.80.com:8080");
+        assert.equal(spyCallArgs.azureAuth, "[...REDACTED...]");
 
         console.log.restore();
     });

--- a/test/log-utils.test.js
+++ b/test/log-utils.test.js
@@ -232,6 +232,31 @@ describe("log-utils.js - Credentials redaction", function() {
         assert.equal(redactedObject.testObj.noRedact, "no-redact");
         assert.equal(redactedObject.noRedact, "no-redact-parent");
     });
+    it("redacts rendition-like object", function() {
+        const testObj = {
+            azureAuth: {
+                aadTenantDomain: 'aadTenantDomain',
+                azureClientId: 'azureClientId',
+                azureClientSecret: 'azureClientSecret'
+            },
+            name: 'transcript.vtt',
+            preset: 'video', // or 'audio'
+        };
+
+        const fieldsToRedact = rewiredRedact.__get__("CREDENTIAL_FIELDS_TO_REDACT");
+        const redactField = rewiredRedact.__get__("redactField");
+        const options = [
+            {redactionList: fieldsToRedact, redactionFn: redactField }
+        ];
+
+        const redact = rewiredRedact.__get__("redact");
+
+        const redactedObject = redact(testObj, options, false);
+
+        assert.equal(redactedObject.azureAuth, "[...REDACTED...]");
+        assert.equal(redactedObject.name, "transcript.vtt");
+        assert.equal(redactedObject.preset, "video");
+    });
 
     it("does nothing when not needed", function() {
         const testObj = {};


### PR DESCRIPTION
## Description

Add `azureAuth` to list of fields to redact.
```
const rendition = {
  azureAuth: {
        aadTenantDomain: 'aadTenantDomain',
        azureClientId: 'azureClientId',
        azureClientSecret: 'azureClientSecret',
        azureMediaAccountName: 'azureMediaAccountName',
        azureResourceGroup: 'azureResourceGroup',
        azureSubscriptionId: 'azureSubscriptionId',
    },
    name: "rendition.vtt",
    fmt: "vtt"
};

AssetComputeLogUtils.log(rendition, "rendition object:");
// should print:
    rendition object: {
         azureAuth: "[...REDACTED...]",
         name: "rendition.vtt",
         fmt: "vtt"
   }

```
I decided to redact the entire azureAuth object instead of the individual keys. That was just for simplicity reasons and so if the names of the credentials change in the future, we won't have to change this code.
part of the fix for: https://jira.corp.adobe.com/browse/NUI-1577

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
