### PR TITLE
ASSETS-8997 add serviceoverload error reason

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -21,7 +21,8 @@ const Reason = Object.freeze({
     RenditionFormatUnsupported: "RenditionFormatUnsupported",
     SourceUnsupported: "SourceUnsupported",
     SourceCorrupt: "SourceCorrupt",
-    RenditionTooLarge: "RenditionTooLarge"
+    RenditionTooLarge: "RenditionTooLarge",
+    ServiceOverLoad: "ServiceOverLoad"
 });
 
 
@@ -74,7 +75,6 @@ class ClientError extends Error {
     }
 }
 
-
 // The requested format is unsupported.
 // To throw error: throw new RenditionFormatUnsupportedError(`The requested format is unsupported`);
 class RenditionFormatUnsupportedError extends ClientError {
@@ -121,6 +121,18 @@ class RenditionTooLarge extends ClientError {
     }
 }
 
+/**
+ * ServiceOverLoad error: Error thrown by actions when a backend API is reporting too many requests.
+ * @param message Error message
+ * @param location Error location, a short greppable string describing the exception location (e.g. "sdk_rendition_upload") 
+ */
+ class ServiceOverLoadError extends ClientError {
+    constructor(message) {
+        super(message, "ServiceOverLoadError", Reason.ServiceOverLoad);
+
+        Error.captureStackTrace(this, ServiceOverLoadError);
+    }
+}
 
 module.exports = {
     GenericError,
@@ -131,5 +143,6 @@ module.exports = {
     SourceUnsupportedError,
     SourceCorruptError,
     RenditionTooLarge,
-    ArgumentError
+    ArgumentError,
+    ServiceOverLoadError
 };


### PR DESCRIPTION
jira: https://jira.corp.adobe.com/browse/ASSETS-8997

This change adds a new `rendition_failed` reason (`ServiceOverLoad`) for use by asset compute workers that encounter upstream API rate limiting and need to indicate to downstream clients that a resubmission of the original asset compute request is necessary after some time has passed.