### PR TITLE
Add new error type: RenditionInstructionError

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -121,6 +121,15 @@ class RenditionTooLarge extends ClientError {
     }
 }
 
+// The rendition instructions were invalid
+class RenditionInstructionError extends ClientError {
+    constructor(message) {
+        super(message, "RenditionInstructionError", Reason.RenditionInstructionError);
+
+        Error.captureStackTrace(this, RenditionInstructionError);
+    }
+}
+
 
 module.exports = {
     GenericError,
@@ -131,5 +140,6 @@ module.exports = {
     SourceUnsupportedError,
     SourceCorruptError,
     RenditionTooLarge,
+    RenditionInstructionError,
     ArgumentError
 };

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -21,7 +21,8 @@ const {
     SourceFormatUnsupportedError,
     SourceUnsupportedError,
     SourceCorruptError,
-    RenditionTooLarge
+    RenditionTooLarge,
+    RenditionInstructionError
 } = require('../lib/errors');
 
 describe("errors", function() {
@@ -96,6 +97,17 @@ describe("errors", function() {
             assert.equal(e.name, "RenditionTooLarge");
             assert.equal(e.message, "hi ho");
             assert.equal(e.reason, Reason.RenditionTooLarge);
+        }
+    });
+    it("RenditionInstructionError", function() {
+        try {
+            throw new RenditionInstructionError("hi ho");
+        } catch (e) {
+            assert.ok(e instanceof ClientError);
+            assert.ok(e instanceof RenditionInstructionError);
+            assert.equal(e.name, "RenditionInstructionError");
+            assert.equal(e.message, "hi ho");
+            assert.equal(e.reason, Reason.RenditionInstructionError);
         }
     });
 });


### PR DESCRIPTION
## Description

I have more than once found myself returning `GenericError` when the rendition instructions are invalid and cannot be used for processing the asset.

Defining here a new error type `RenditionInstructionError` that states just that.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
